### PR TITLE
SIANXSVC-1170: Ensure debug symbols are created

### DIFF
--- a/src/Anexia.E5E/Anexia.E5E.csproj
+++ b/src/Anexia.E5E/Anexia.E5E.csproj
@@ -30,6 +30,12 @@
 		<!-- Build a *.snupkg symbol package for easier debugging: https://learn.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg#creating-a-symbol-package -->
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+
+		<!--
+			SIANXSVC-1170: Set the debug type to "Portable". This allows the generation of proper *.pdb files in the *.snupkg files.
+			Thanks to Piedone for the relevant NuGet discussion: https://github.com/NuGet/Home/discussions/11541
+		-->
+		<DebugType>portable</DebugType>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -50,5 +56,4 @@
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0"/>
 		<PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="All"/>
 	</ItemGroup>
-
 </Project>


### PR DESCRIPTION
In our case, it was added by the Dotnet.ReproduciblePackages, which
recommends it for smaller OSS libraries [1]. Nonetheless, I've decided
to use the new *.snupkg format to have a future-proof and SourceLink [2]
compatible way for debug symbols.

[1]: https://github.com/dotnet/reproducible-builds/issues/18
[2]: https://github.com/dotnet/sourcelink

---

By running `unzip -l *.snupkg` we can also confirm that the `*.pdb` symbols are added:

```
Archive:  Anexia.E5E.1.0.0.snupkg
  Length      Date    Time    Name
---------  ---------- -----   ----
      500  12-13-2023 14:54   _rels/.rels
     1225  12-13-2023 14:54   Anexia.E5E.nuspec
    28832  12-13-2023 13:54   lib/net6.0/Anexia.E5E.pdb
    56140  12-13-2023 13:54   lib/net8.0/Anexia.E5E.pdb
      459  12-13-2023 14:54   [Content_Types].xml
      693  12-13-2023 14:54   package/services/metadata/core-properties/2a7522e1a1524bec8a99a0f3ff2df42b.psmdcp
---------                     -------
    87849                     6 files
```