### PR TITLE
SIANXSVC-1178: Ensure tag gets used for NuGet versioning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
         git branch --remote --contains | grep origin/main
 
     - name: Set VERSION variable from tag
-      run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
+      run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
 
     - uses: actions/setup-dotnet@v3
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,12 +16,15 @@ jobs:
 
     - name: Set VERSION variable from tag
       run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
+
     - uses: actions/setup-dotnet@v3
       with:
        dotnet-version: "8.0.x"
        cache: true
        cache-dependency-path: src/**/packages.lock.json
+
     - run: dotnet restore --locked-mode
+
     - run: dotnet pack --no-restore --include-symbols -o . /p:Version=${VERSION}
 
     - name: Deploy to NuGet

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
 
     - run: dotnet restore --locked-mode
 
-    - run: dotnet pack --no-restore --include-symbols -o . /p:Version=${VERSION}
+    - run: dotnet pack --no-restore --include-symbols -o . /p:PackageVersion=${VERSION}
 
     - name: Deploy to NuGet
       run: dotnet nuget push *.nupkg --api-key $NUGET_AUTH_TOKEN --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
- Add blank lines as a little christmas gift :3
- Simplify v-prefix removal
- Use PackageVersion instead of Version

The last commit is the actual fix. I've tried it locally and it's working as intended.
