### PR TITLE
SIANXSVC-1193: dotnet-e5e does not handle binary requests as expected

### DIFF
--- a/examples/InlineHandler/Program.cs
+++ b/examples/InlineHandler/Program.cs
@@ -9,6 +9,18 @@ await Host.CreateDefaultBuilder(args)
 			var res = E5EResponse.From("test");
 			return Task.FromResult(res);
 		});
+		builder.RegisterEntrypoint("Binary", request =>
+		{
+			// This entrypoint receives one file (type: binary) and returns an anonymous object with the length.
+			var fileData = request.Event.AsBytes();
+			return Task.FromResult(E5EResponse.From(new { FileLength = fileData?.LongLength }));
+		});
+		builder.RegisterEntrypoint("ReturnFirstFile", request =>
+		{
+			// This entrypoint receives multiple files as a mixed request and returns the first.
+			var files = request.Event.AsFiles();
+			return Task.FromResult(E5EResponse.From(files.First()));
+		});
 	})
 	.UseConsoleLifetime()
 	.Build()

--- a/src/Anexia.E5E.Tests/Anexia.E5E.Tests.csproj
+++ b/src/Anexia.E5E.Tests/Anexia.E5E.Tests.csproj
@@ -4,6 +4,7 @@
 		<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
+		<LangVersion>12</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -25,6 +26,15 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\Anexia.E5E\Anexia.E5E.csproj"/>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <None Update="TestData\binary_request_with_multiple_files.json">
+	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </None>
+	  <None Update="TestData\binary_request_unknown_content_type.json">
+	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </None>
 	</ItemGroup>
 
 </Project>

--- a/src/Anexia.E5E.Tests/Integration/BinaryRequestIntegrationTests.cs
+++ b/src/Anexia.E5E.Tests/Integration/BinaryRequestIntegrationTests.cs
@@ -1,0 +1,107 @@
+using System.Threading.Tasks;
+
+using Anexia.E5E.Exceptions;
+using Anexia.E5E.Functions;
+using Anexia.E5E.Tests.TestHelpers;
+
+using static Anexia.E5E.Tests.TestData.TestData;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Anexia.E5E.Tests.Integration;
+
+public sealed class BinaryRequestIntegrationTests(ITestOutputHelper outputHelper) : IntegrationTestBase(outputHelper)
+{
+	[Fact]
+	public async Task DecodeToBytesThrowsForMixedRequest()
+	{
+		await Host.StartWithTestEntrypointAsync(request =>
+		{
+			Assert.Throws<E5EInvalidConversionException>(() => request.Event.AsBytes());
+			return null!;
+		});
+		await Host.WriteOnceAsync(BinaryRequestWithMultipleFiles);
+	}
+
+	[Fact]
+	public async Task MultipleFilesAreProperlyDecoded()
+	{
+		await Host.StartWithTestEntrypointAsync(request =>
+		{
+			var content = "Hello world!"u8.ToArray();
+			var files = request.Event.AsFiles();
+			Assert.Collection(files, first =>
+			{
+				Assert.NotNull(first);
+				Assert.Equivalent(first, new E5EFileData(content)
+				{
+					FileSizeInBytes = 12,
+					Filename = "my-file-1.name",
+					ContentType = "application/my-content-type-1",
+					Charset = "utf-8",
+				});
+			}, second =>
+			{
+				Assert.NotNull(second);
+				Assert.Equivalent(second, new E5EFileData(content)
+				{
+					FileSizeInBytes = 12,
+					Filename = "my-file-2.name",
+					ContentType = "application/my-content-type-2",
+					Charset = "utf-8",
+				});
+			});
+			return null!;
+		});
+		await Host.WriteOnceAsync(BinaryRequestWithMultipleFiles);
+	}
+
+	[Fact]
+	public async Task UnknownContentType()
+	{
+		await Host.StartWithTestEntrypointAsync(request =>
+		{
+			Assert.Equal("Hello world!"u8.ToArray(), request.Event.AsBytes());
+			return null!;
+		});
+		await Host.WriteOnceAsync(BinaryRequestWithUnknownContentType);
+	}
+
+	[Fact]
+	public async Task FallbackForByteArrayReturnsValidResponse()
+	{
+		// act
+		await Host.StartWithTestEntrypointAsync(_ => E5EResponse.From("Hello world!"u8.ToArray()));
+		var response = await Host.WriteOnceAsync(x => x.WithData("test"));
+
+		// assert
+		const string expected =
+			"""
+			{"data":{"binary":"SGVsbG8gd29ybGQh","type":"binary","size":0,"name":"dotnet-e5e-binary-response.blob","content_type":"application/octet-stream","charset":"utf-8"},"type":"binary"}
+			""";
+		Assert.Contains(expected, response.Stdout);
+	}
+
+	[Fact]
+	public async Task FileDataReturnsValidResponse()
+	{
+		// act
+		await Host.StartWithTestEntrypointAsync(_ => E5EResponse.From(new E5EFileData("Hello world!"u8.ToArray())
+		{
+			Type = "binary",
+			FileSizeInBytes = 16,
+			Filename = "hello-world.txt",
+			ContentType = "text/plain",
+			Charset = "utf-8",
+		}));
+		var response = await Host.WriteOnceAsync(x => x.WithData("test"));
+
+		// assert
+		const string expected =
+			"""
+			{"data":{"binary":"SGVsbG8gd29ybGQh","type":"binary","size":16,"name":"hello-world.txt","content_type":"text/plain","charset":"utf-8"},"type":"binary"}
+			""";
+		Assert.Contains(expected, response.Stdout);
+	}
+}

--- a/src/Anexia.E5E.Tests/Integration/DocumentationTests.cs
+++ b/src/Anexia.E5E.Tests/Integration/DocumentationTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 using Anexia.E5E.Functions;
@@ -42,7 +43,11 @@ public class DocumentationTests : IntegrationTestBase
 			var data = request.Event.As<SumData>()!;
 			return E5EResponse.From(data.A + data.B);
 		});
-		var response = await Host.WriteRequestOnceAsync(x => x.WithData(new SumData { A = 3, B = 2 }));
+		var response = await Host.WriteRequestOnceAsync(x => x.WithData(new SumData
+		{
+			A = 3,
+			B = 2,
+		}));
 		Assert.Equal(5, response.As<int>());
 	}
 
@@ -55,8 +60,8 @@ public class DocumentationTests : IntegrationTestBase
 			var resp = Encoding.UTF8.GetBytes($"Hello {name}");
 			return E5EResponse.From(resp);
 		});
-		var response = await Host.WriteRequestOnceAsync(x => x.WithData(Encoding.UTF8.GetBytes("Luna")));
-		Assert.Equal("\"SGVsbG8gTHVuYQ==\"", response.Data.GetRawText());
+		var response = await Host.WriteRequestOnceAsync(x => x.WithData(new E5EFileData("Luna"u8.ToArray())));
+		Assert.Equal("Hello Luna"u8.ToArray(), response.Data.Deserialize<E5EFileData>()!.Bytes);
 		Assert.Equal(E5EResponseType.Binary, response.Type);
 	}
 

--- a/src/Anexia.E5E.Tests/Serialization/snapshots/SerializationTests.RequestSerializationMatchesSnapshot_testName=simple binary request.verified.txt
+++ b/src/Anexia.E5E.Tests/Serialization/snapshots/SerializationTests.RequestSerializationMatchesSnapshot_testName=simple binary request.verified.txt
@@ -1,1 +1,1 @@
-﻿{"type":"binary","data":"dGVzdA=="}
+﻿{"type":"binary","data":{"binary":"aGVsbG8=","type":"binary","size":0,"name":null,"content_type":null,"charset":"utf-8"}}

--- a/src/Anexia.E5E.Tests/Serialization/snapshots/SerializationTests.ResponseSerializationMatchesSnapshot_testName=simple binary response.verified.txt
+++ b/src/Anexia.E5E.Tests/Serialization/snapshots/SerializationTests.ResponseSerializationMatchesSnapshot_testName=simple binary response.verified.txt
@@ -1,1 +1,1 @@
-﻿{"data":"dGVzdA==","type":"binary"}
+﻿{"data":{"binary":"aGVsbG8=","type":"binary","size":0,"name":"dotnet-e5e-binary-response.blob","content_type":"application/octet-stream","charset":"utf-8"},"type":"binary"}

--- a/src/Anexia.E5E.Tests/TestData/TestData.cs
+++ b/src/Anexia.E5E.Tests/TestData/TestData.cs
@@ -1,0 +1,11 @@
+using System.IO;
+
+namespace Anexia.E5E.Tests.TestData;
+
+internal static class TestData
+{
+	private static string ReadTestDataFile(string path) => File.ReadAllText(Path.Combine(Directory.GetCurrentDirectory(), "TestData", path));
+
+	internal static string BinaryRequestWithMultipleFiles => ReadTestDataFile("binary_request_with_multiple_files.json");
+	internal static string BinaryRequestWithUnknownContentType => ReadTestDataFile("binary_request_unknown_content_type.json");
+}

--- a/src/Anexia.E5E.Tests/TestData/binary_request_unknown_content_type.json
+++ b/src/Anexia.E5E.Tests/TestData/binary_request_unknown_content_type.json
@@ -1,0 +1,18 @@
+{
+	"context": {
+		"type": "integration-test",
+		"async": true,
+		"date": "2024-01-01T00:00:00Z"
+	},
+	"event": {
+		"type": "binary",
+		"data": {
+			"binary": "SGVsbG8gd29ybGQh",
+			"type": "binary",
+			"name": "my-file-1.name",
+			"size": 12,
+			"content_type": "application/my-content-type-1",
+			"charset": "utf-8"
+		}
+	}
+}

--- a/src/Anexia.E5E.Tests/TestData/binary_request_with_multiple_files.json
+++ b/src/Anexia.E5E.Tests/TestData/binary_request_with_multiple_files.json
@@ -1,0 +1,28 @@
+{
+	"context": {
+		"type": "integration-test",
+		"async": true,
+		"date": "2024-01-01T00:00:00Z"
+	},
+	"event": {
+		"type": "mixed",
+		"data": [
+			{
+				"binary": "SGVsbG8gd29ybGQh",
+				"type": "binary",
+				"name": "my-file-1.name",
+				"size": 12,
+				"content_type": "application/my-content-type-1",
+				"charset": "utf-8"
+			},
+			{
+				"binary": "SGVsbG8gd29ybGQh",
+				"type": "binary",
+				"name": "my-file-2.name",
+				"size": 12,
+				"content_type": "application/my-content-type-2",
+				"charset": "utf-8"
+			}
+		]
+	}
+}

--- a/src/Anexia.E5E.Tests/TestHelpers/TestRequestBuilder.cs
+++ b/src/Anexia.E5E.Tests/TestHelpers/TestRequestBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text.Json;
 
@@ -17,7 +18,9 @@ public class TestRequestBuilder
 		_requestType = data switch
 		{
 			string => E5ERequestDataType.Text,
-			IEnumerable<byte> => E5ERequestDataType.Binary,
+			IEnumerable<byte> => throw new InvalidOperationException(
+				$"E5E does not compose binary requests just from the bytes. Please convert this call to use {nameof(E5EFileData)} instead."),
+			E5EFileData => E5ERequestDataType.Binary,
 			_ => E5ERequestDataType.StructuredObject,
 		};
 		_data = JsonSerializer.SerializeToElement(data);

--- a/src/Anexia.E5E/Exceptions/E5EInvalidConversionException.cs
+++ b/src/Anexia.E5E/Exceptions/E5EInvalidConversionException.cs
@@ -10,16 +10,21 @@ namespace Anexia.E5E.Exceptions;
 [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
 public class E5EInvalidConversionException : E5EException
 {
-	private E5EInvalidConversionException(E5ERequestDataType expected, E5ERequestDataType actual)
-		: base($"Cannot convert data of type {actual} into the type {expected}")
+	private E5EInvalidConversionException(E5ERequestDataType actual, E5ERequestDataType[] allowedTypes)
+		: base($"Cannot convert data of type {actual} into one of {actual}")
 	{
-		Expected = expected;
+		AllowedTypes = allowedTypes;
 		Actual = actual;
+#pragma warning disable CS0618 // Type or member is obsolete
+		Expected = allowedTypes[0];
+#pragma warning restore CS0618 // Type or member is obsolete
 	}
 
 	/// <summary>
-	///     The required data type for this conversion call.
+	///     The required data type for this conversion call. Obsolete, got replaced with <see cref="AllowedTypes"/>.
 	/// </summary>
+	[Obsolete(
+		"The library got support for multiple allowedTypes data types per conversion. Please migrate this call to AllowedTypes.")]
 	public E5ERequestDataType Expected { get; }
 
 	/// <summary>
@@ -27,9 +32,14 @@ public class E5EInvalidConversionException : E5EException
 	/// </summary>
 	public E5ERequestDataType Actual { get; }
 
-	internal static void ThrowIfNotMatch(E5ERequestDataType expected, E5ERequestDataType actual)
+	/// <summary>
+	/// The allowed data types for this conversion call.
+	/// </summary>
+	public E5ERequestDataType[] AllowedTypes { get; }
+
+	internal static void ThrowIfNotMatch(E5ERequestDataType value, params E5ERequestDataType[] allowed)
 	{
-		if (expected != actual)
-			throw new E5EInvalidConversionException(expected, actual);
+		if (!allowed.Contains(value))
+			throw new E5EInvalidConversionException(value, allowed);
 	}
 }

--- a/src/Anexia.E5E/Functions/E5EFileData.cs
+++ b/src/Anexia.E5E/Functions/E5EFileData.cs
@@ -1,0 +1,59 @@
+using System.Text.Json.Serialization;
+
+namespace Anexia.E5E.Functions;
+
+/// <summary>
+/// Contains information about the files that were attached to this request.
+/// </summary>
+/// <remarks>For requests, it requires that it has the type of <see cref="E5ERequestDataType.Binary"/> or <see cref="E5ERequestDataType.Mixed"/>.</remarks>
+public sealed record E5EFileData
+{
+	/// <summary>
+	/// The contents of the file, encoded in the charset given by <see cref="Charset"/>.
+	/// </summary>
+	[JsonPropertyName("binary")]
+	public byte[] Bytes { get; } = Array.Empty<byte>();
+
+	/// <summary>
+	/// The type of this binary, usually just <code>binary</code>.
+	/// </summary>
+	[JsonPropertyName("type")]
+	public string Type { get; init; } = "binary";
+
+	/// <summary>
+	/// The size of the file in bytes. Can be zero if it cannot be determined reliably.
+	/// </summary>
+	[JsonPropertyName("size")]
+	public long FileSizeInBytes { get; init; }
+
+	/// <summary>
+	/// The optional filename of the file.
+	/// </summary>
+	[JsonPropertyName("name")]
+	public string? Filename { get; init; }
+
+	/// <summary>
+	/// The content type of the file.
+	/// </summary>
+	/// <remarks>
+	/// For responses, the <code>Content-Type</code> header is set automatically by the E5E engine to this value.
+	/// </remarks>
+	[JsonPropertyName("content_type")]
+	public string? ContentType { get; init; }
+
+	/// <summary>
+	/// The charset of the file. Recommended and also the default value is "utf-8".
+	/// </summary>
+	[JsonPropertyName("charset")]
+	public string Charset { get; init; } = "utf-8";
+
+	/// <summary>
+	/// Creates a new file from the given bytes with "utf-8" as the charset.
+	/// </summary>
+	/// <param name="bytes">The contents of the file.</param>
+	public E5EFileData(byte[] bytes)
+	{
+		Charset = "utf-8";
+		Bytes = bytes;
+	}
+}

--- a/src/Anexia.E5E/Functions/E5EResponse.cs
+++ b/src/Anexia.E5E/Functions/E5EResponse.cs
@@ -2,6 +2,9 @@ using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Text.Json;
 
+using Anexia.E5E.Exceptions;
+using Anexia.E5E.Serialization;
+
 namespace Anexia.E5E.Functions;
 
 /// <summary>
@@ -30,6 +33,26 @@ public class E5EResponse
 	public E5EHttpHeaders? ResponseHeaders { get; init; }
 
 	/// <summary>
+	///     Creates a new <see cref="E5EResponse" /> from the given text with the type
+	///     <see cref="E5EResponseType.Text" />.
+	/// </summary>
+	/// <param name="text">The text to encode.</param>
+	/// <param name="status">An optional HTTP status code.</param>
+	/// <param name="responseHeaders">An optional list of HTTP headers.</param>
+	/// <returns>A valid <see cref="E5EResponse" /> with the given data.</returns>
+	public static E5EResponse From(string text, HttpStatusCode? status = null,
+		E5EHttpHeaders? responseHeaders = null)
+	{
+		return new E5EResponse
+		{
+			Type = E5EResponseType.Text,
+			Data = JsonSerializer.SerializeToElement(text, E5ESerializationContext.Default.String),
+			Status = status,
+			ResponseHeaders = responseHeaders,
+		};
+	}
+
+	/// <summary>
 	///     Creates a new <see cref="E5EResponse" /> from the given object with the type
 	///     <see cref="E5EResponseType.StructuredObject" />.
 	/// </summary>
@@ -44,18 +67,90 @@ public class E5EResponse
 		"This helper relies on runtime reflection for the JSON serialization. Initialize the E5EResponse by yourself for AOT.")]
 #endif
 	public static E5EResponse From<T>(T data, HttpStatusCode? status = null, E5EHttpHeaders? responseHeaders = null)
+		where T : notnull
 	{
 		return new E5EResponse
 		{
-			Type = data switch
-			{
-				IEnumerable<char> => E5EResponseType.Text,
-				IEnumerable<byte> => E5EResponseType.Binary,
-				_ => E5EResponseType.StructuredObject,
-			},
+			Type = E5EResponseType.StructuredObject,
 			Data = JsonSerializer.SerializeToElement(data),
 			Status = status,
 			ResponseHeaders = responseHeaders,
 		};
+	}
+
+	/// <summary>
+	///     Creates a new <see cref="E5EResponse" /> from the given file with the type
+	///     <see cref="E5EResponseType.Binary" />.
+	/// </summary>
+	/// <param name="file">The file contents.</param>
+	/// <param name="status">An optional HTTP status code.</param>
+	/// <param name="responseHeaders">An optional list of HTTP headers.</param>
+	/// <returns>A valid <see cref="E5EResponse" /> with the given data.</returns>
+
+#if !NET8_0_OR_GREATER
+	[RequiresUnreferencedCode(
+		"This helper relies on runtime reflection for the JSON serialization.")]
+#endif
+	public static E5EResponse From(E5EFileData file, HttpStatusCode? status = null,
+		E5EHttpHeaders? responseHeaders = null)
+	{
+		return new E5EResponse
+		{
+			Type = E5EResponseType.Binary,
+#if NET8_0_OR_GREATER
+			Data = JsonSerializer.SerializeToElement(file, E5ESerializationContext.Default.E5EFileData),
+#else
+			Data = JsonSerializer.SerializeToElement(file, E5EJsonSerializerOptions.Default),
+#endif
+			Status = status,
+			ResponseHeaders = responseHeaders,
+		};
+	}
+
+	/// <summary>
+	///     Creates a new <see cref="E5EResponse" /> from the given object with the type
+	///     <see cref="E5EResponseType.Binary" />.
+	/// </summary>
+	/// <remarks>For further control about the information that is sent to the client (filename, charset, etc.), it's recommended to use the <see cref="E5EFileData"/> instead.</remarks>
+	/// <param name="data">The raw binary contents.</param>
+	/// <param name="status">An optional HTTP status code.</param>
+	/// <param name="responseHeaders">An optional list of HTTP headers.</param>
+	/// <returns>A valid <see cref="E5EResponse" /> with the given data.</returns>
+	[RequiresUnreferencedCode(
+		"This helper relies on runtime reflection for the JSON serialization. Initialize the E5EResponse by yourself for AOT.")]
+#if NET8_0_OR_GREATER
+	[RequiresDynamicCode(
+		"This helper relies on runtime reflection for the JSON serialization. Initialize the E5EResponse by yourself for AOT.")]
+#endif
+	public static E5EResponse From(IEnumerable<byte> data, HttpStatusCode? status = null,
+		E5EHttpHeaders? responseHeaders = null)
+	{
+		return From(data.ToArray());
+	}
+
+	/// <summary>
+	///     Creates a new <see cref="E5EResponse" /> from the given object with the type
+	///     <see cref="E5EResponseType.Binary" />.
+	/// </summary>
+	/// <remarks>For further control about the information that is sent to the client (filename, charset, etc.), it's recommended to use the <see cref="E5EFileData"/> instead.</remarks>
+	/// <param name="data">The raw binary contents.</param>
+	/// <param name="status">An optional HTTP status code.</param>
+	/// <param name="responseHeaders">An optional list of HTTP headers.</param>
+	/// <returns>A valid <see cref="E5EResponse" /> with the given data.</returns>
+	[RequiresUnreferencedCode(
+		"This helper relies on runtime reflection for the JSON serialization. Initialize the E5EResponse by yourself for AOT.")]
+#if NET8_0_OR_GREATER
+	[RequiresDynamicCode(
+		"This helper relies on runtime reflection for the JSON serialization. Initialize the E5EResponse by yourself for AOT.")]
+#endif
+	public static E5EResponse From(byte[] data, HttpStatusCode? status = null,
+		E5EHttpHeaders? responseHeaders = null)
+	{
+		return From(
+			new E5EFileData(data)
+			{
+				ContentType = "application/octet-stream",
+				Filename = "dotnet-e5e-binary-response.blob",
+			}, status, responseHeaders);
 	}
 }

--- a/src/Anexia.E5E/Serialization/E5ESerializationContext.cs
+++ b/src/Anexia.E5E/Serialization/E5ESerializationContext.cs
@@ -7,7 +7,6 @@ using Anexia.E5E.Serialization.Converters;
 
 namespace Anexia.E5E.Serialization;
 
-[JsonSerializable(typeof(byte[]))]
 [JsonSerializable(typeof(string))]
 #if NET8_0_OR_GREATER
 // The .NET 6 JSON generation is very limited, especially with the lack of init-only properties.
@@ -15,6 +14,8 @@ namespace Anexia.E5E.Serialization;
 [JsonSerializable(typeof(E5ERequest))]
 [JsonSerializable(typeof(E5EResponse))]
 [JsonSerializable(typeof(E5ERuntimeMetadata))]
+[JsonSerializable(typeof(E5EFileData))]
+[JsonSerializable(typeof(IEnumerable<E5EFileData>))]
 [JsonSourceGenerationOptions(
 	JsonSerializerDefaults.General,
 	IgnoreReadOnlyProperties = false,


### PR DESCRIPTION
Closes SIANXSVC-1193.

This PR introduces a new `E5EFileData` class for proper serialization and deserialization of files.
Old methods were updated to use this new serialization method.
Furthermore, new methods were added to make use of the file deserialization.

Examples got added to the InlineHandler project.
