### PR TITLE
SIANXSVC-1204: Wrap response inside a result

### DIFF
--- a/src/Anexia.E5E.Tests/Integration/E5ECommunicationServiceTests.cs
+++ b/src/Anexia.E5E.Tests/Integration/E5ECommunicationServiceTests.cs
@@ -83,7 +83,7 @@ public class E5ECommunicationServiceTests : IntegrationTestBase
 	{
 		await Host.StartWithTestEntrypointAsync(_ => E5EResponse.From("response"));
 		var (stdout, _) = await Host.WriteOnceAsync(builder => builder.WithData("request"));
-		Assert.Equal(@"+++{""data"":""response"",""type"":""text""}---", stdout);
+		Assert.Equal(@"+++{""result"":{""data"":""response"",""type"":""text""}}---", stdout);
 	}
 
 	[Fact]

--- a/src/Anexia.E5E.Tests/TestHelpers/TestHostBuilder.cs
+++ b/src/Anexia.E5E.Tests/TestHelpers/TestHostBuilder.cs
@@ -119,10 +119,12 @@ public class TestHostBuilder
 		var json = stdout
 			.Replace(options.StdoutTerminationSequence, "")
 			.Replace(options.DaemonExecutionTerminationSequence, "");
-		var resp = JsonSerializer.Deserialize<E5EResponse>(json, E5EJsonSerializerOptions.Default);
 
-		// ReSharper disable once NullableWarningSuppressionIsUsed
-		return resp!;
+		var result = JsonSerializer.Deserialize<JsonElement>(json, E5EJsonSerializerOptions.Default);
+		if (!result.TryGetProperty("result", out result))
+			throw new InvalidOperationException("The response does not contain a 'result' property");
+
+		return result.Deserialize<E5EResponse>(E5EJsonSerializerOptions.Default)!;
 	}
 
 	public Task StartWithTestEntrypointAsync(Func<E5ERequest, E5EResponse> handler)


### PR DESCRIPTION
The older pattern is not longer supported by e5e and therefore this
library needs to be fixed.

Closes SIANXSVC-1204
