### PR TITLE
SIANXSVC-1203: Ensure library_version has correct value

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
 
     - run: dotnet restore
 
-    - run: dotnet pack --no-restore --include-symbols -o . /p:PackageVersion=${VERSION}
+    - run: dotnet pack --no-restore --include-symbols -o . /p:Version=${VERSION}
 
     - name: Deploy to NuGet
       run: dotnet nuget push *.nupkg --api-key $NUGET_AUTH_TOKEN --source https://api.nuget.org/v3/index.json

--- a/src/Anexia.E5E.Tests/Integration/StartupTests.cs
+++ b/src/Anexia.E5E.Tests/Integration/StartupTests.cs
@@ -25,7 +25,7 @@ public class StartupTests : IntegrationTestBase
 	public async Task OutputMatches()
 	{
 		await Host.StartAsync();
-		var expected = JsonSerializer.Serialize(new E5ERuntimeMetadata(), E5EJsonSerializerOptions.Default);
+		var expected = JsonSerializer.Serialize(E5ERuntimeMetadata.Current, E5EJsonSerializerOptions.Default);
 		var stdout = await Host.GetStdoutAsync();
 		Assert.Equal(expected, stdout);
 	}

--- a/src/Anexia.E5E.Tests/Serialization/SerializationTests.cs
+++ b/src/Anexia.E5E.Tests/Serialization/SerializationTests.cs
@@ -100,7 +100,7 @@ public class SerializationTests
 		Assert.Equal(E5EResponseType.Binary, E5EResponse.From("test"u8.ToArray()).Type);
 		Assert.Equal(E5EResponseType.Binary, E5EResponse.From("test"u8.ToArray().AsEnumerable()).Type);
 		Assert.Equal(E5EResponseType.Binary, E5EResponse.From(new E5EFileData("something"u8.ToArray())).Type);
-		Assert.Equal(E5EResponseType.StructuredObject, E5EResponse.From(new E5ERuntimeMetadata()).Type);
+		Assert.Equal(E5EResponseType.StructuredObject, E5EResponse.From(E5ERuntimeMetadata.Current).Type);
 	}
 
 	[Theory]
@@ -125,7 +125,7 @@ public class SerializationTests
 	[Fact]
 	public void MetadataIsProperSerialized()
 	{
-		var json = JsonSerializer.Serialize(new E5ERuntimeMetadata(), _options);
+		var json = JsonSerializer.Serialize(E5ERuntimeMetadata.Current, _options);
 		var deserialized = JsonSerializer.Deserialize<JsonElement>(json);
 		var sut = deserialized.EnumerateObject().ToDictionary(x => x.Name, x => x.Value);
 
@@ -135,7 +135,8 @@ public class SerializationTests
 			() => Assert.Contains("runtime", sut),
 			() => Assert.Contains("features", sut),
 			() => Assert.Contains("library_version", sut),
-			() => Assert.Equal(1, sut["features"].GetArrayLength())
+			() => Assert.Equal(1, sut["features"].GetArrayLength()),
+			() => Assert.Equal("1.0.0", sut["library_version"].GetString())
 		);
 	}
 
@@ -158,7 +159,7 @@ public class SerializationTests
 		{
 			new E5EContext("generic", DateTimeOffset.FromUnixTimeSeconds(0), true),
 			new E5ERequestParameters(),
-			new E5ERuntimeMetadata(),
+			E5ERuntimeMetadata.Current,
 			new E5EFileData("data"u8.ToArray()),
 		};
 

--- a/src/Anexia.E5E/Anexia.E5E.csproj
+++ b/src/Anexia.E5E/Anexia.E5E.csproj
@@ -8,7 +8,6 @@
 
 		<!-- NuGet specific metadata, according to: https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/nuget#important-nuget-package-metadata -->
 		<PackageId>Anexia.E5E</PackageId>
-		<PackageVersion>1.0.0</PackageVersion> <!-- This is a placeholder, overridden by Nerdbank.GitVersioning -->
 		<Description>A helper library to help you build serverless functions on top of the Anexia Engine.</Description>
 		<Authors>anexia</Authors> <!-- needs to match the NuGet profiles -->
 		<Company>ANEXIA Internetdienstleistungs GmbH</Company>

--- a/src/Anexia.E5E/Hosting/E5EHostWrapper.cs
+++ b/src/Anexia.E5E/Hosting/E5EHostWrapper.cs
@@ -39,10 +39,10 @@ internal sealed class E5EHostWrapper : IHost
 		}
 
 #if NET8_0_OR_GREATER
-		var metadata = JsonSerializer.Serialize(new E5ERuntimeMetadata(),
+		var metadata = JsonSerializer.Serialize(E5ERuntimeMetadata.Current,
 			E5ESerializationContext.Default.E5ERuntimeMetadata);
 #else
-		var metadata = JsonSerializer.Serialize(new E5ERuntimeMetadata(), E5EJsonSerializerOptions.Default);
+		var metadata = JsonSerializer.Serialize(E5ERuntimeMetadata.Current, E5EJsonSerializerOptions.Default);
 #endif
 
 		_console.Open();

--- a/src/Anexia.E5E/Runtime/E5ERuntimeMetadata.cs
+++ b/src/Anexia.E5E/Runtime/E5ERuntimeMetadata.cs
@@ -8,8 +8,19 @@ namespace Anexia.E5E.Runtime;
 /// </summary>
 [SuppressMessage("ReSharper", "UnusedMember.Global")]
 [SuppressMessage("Performance", "CA1822:Mark members as static")]
-public record E5ERuntimeMetadata
+public sealed record E5ERuntimeMetadata
 {
+	private E5ERuntimeMetadata()
+	{
+		// We try to fetch the informational version from the generated AssemblyInfo. Because SourceLink appends the
+		// commit hash, we have to trim it afterwards.
+		var version = typeof(E5ERuntimeMetadata).Assembly
+			.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+			?.InformationalVersion ?? "0.0.0+unknown";
+
+		LibraryVersion = version[..version.IndexOf('+')];
+	}
+
 	/// <summary>
 	///     The current instance of the metadata.
 	/// </summary>
@@ -18,9 +29,7 @@ public record E5ERuntimeMetadata
 	/// <summary>
 	///     The installed version of this NuGet library.
 	/// </summary>
-	public string LibraryVersion =>
-		typeof(E5ERuntimeMetadata).Assembly.GetCustomAttribute<AssemblyVersionAttribute>()?.Version ??
-		"0.0.0-unrecognized";
+	public string LibraryVersion { get; }
 
 	/// <summary>
 	///     The runtime this function is running in.


### PR DESCRIPTION
Several things had to get fixed in order for the library version to
appear in the metadata. First and foremost, the GitHub Actions workflow
was setting the `PackageVersion` (which is used for the NuGet package),
but not the `AssemblyVersion`. This is now fixed by passing the tag via
`/p:Version`.

Second, the current retrieved version included the commit hash, which
would have ended up to conflict with the database constraints of E5E
which limit the version to 20 characters. In order to circumvent this
problem, the hash is trimmed from the version.

Because I had the time to work on this part of the code, I took the
opportunity and made the `E5ERuntimeMetadata` sealed. Technically, this is
a breaking change, however I don't expect that anyone is affected by it,
so for me it'd be fine to put it in a patch release.


