### PR TITLE
Remove the action to publish the test results

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,13 +26,5 @@ jobs:
     - name: Run tests with coverage
       run: dotnet test --no-restore --collect:"XPlat Code Coverage" /p:CoverletOutputFormat=opencover --logger trx --results-directory "test-results"
 
-    - name: Publish test results (${{ matrix.dotnet-version }})
-      uses: EnricoMi/publish-unit-test-result-action@v2
-      if: always()
-      with:
-        comment_mode: off
-        files: |
-          test-results/**/*.trx
-
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3


### PR DESCRIPTION
Apparently, we're now affected by [this issue here](https://github.com/EnricoMi/publish-unit-test-result-action/issues/12) (tl;dr: the GitHub
API is kinda broken) and therefore publishing the test results is
failing randomly.

I've removed the step, as the workflow already ensures that the tests run.
This should fix the merge issues in all the dependabot PRs.