### PR TITLE
SIANXSVC-1206: dotnet-e5e writes logging messages after output in non-keepalive mode

### DIFF
--- a/src/Anexia.E5E.Tests/Integration/NonKeepAliveModeTests.cs
+++ b/src/Anexia.E5E.Tests/Integration/NonKeepAliveModeTests.cs
@@ -1,0 +1,39 @@
+using System.Threading.Tasks;
+
+using Anexia.E5E.Functions;
+using Anexia.E5E.Tests.Helpers;
+using Anexia.E5E.Tests.TestHelpers;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Anexia.E5E.Tests.Integration;
+
+public class NonKeepAliveModeTests : IntegrationTestBase
+{
+	public NonKeepAliveModeTests(ITestOutputHelper outputHelper) : base(outputHelper)
+	{
+		Host.ConfigureEndpoints(cfg =>
+		{
+			cfg.RegisterEntrypoint(TestE5ERuntimeOptions.DefaultEntrypointName,
+				_ => Task.FromResult(E5EResponse.From("response")));
+		}, new[] { TestE5ERuntimeOptions.DefaultEntrypointName, "+++", "0", "---" });
+	}
+
+	public override Task InitializeAsync() => Host.StartAsync();
+
+
+	[Fact]
+	public async Task ShouldEndWithJsonResponse()
+	{
+		var (stdout, _) = await Host.WriteOnceAsync(builder => builder.WithData("request"));
+		Assert.EndsWith(@"{""result"":{""data"":""response"",""type"":""text""}}", stdout);
+	}
+
+	[Fact]
+	public async Task ShouldNotWriteExecutionEndToStderr()
+	{
+		var (_, stderr) = await Host.WriteOnceAsync(builder => builder.WithData("request"));
+		Assert.Empty(stderr);
+	}
+}

--- a/src/Anexia.E5E.Tests/TestHelpers/IntegrationTestBase.cs
+++ b/src/Anexia.E5E.Tests/TestHelpers/IntegrationTestBase.cs
@@ -15,7 +15,7 @@ public abstract class IntegrationTestBase : XunitContextBase, IAsyncLifetime
 
 	protected TestHostBuilder Host { get; }
 
-	public Task InitializeAsync()
+	public virtual Task InitializeAsync()
 	{
 		return Task.CompletedTask;
 	}

--- a/src/Anexia.E5E/Hosting/E5ECommunicationService.cs
+++ b/src/Anexia.E5E/Hosting/E5ECommunicationService.cs
@@ -90,13 +90,15 @@ internal sealed class E5ECommunicationService : BackgroundService
 			var response = await RespondToLineAsync(line, stoppingToken).ConfigureAwait(false);
 			await _console.WriteToStdoutAsync(response).ConfigureAwait(false);
 
-			// After every *successful* execution, we need to write the execution sequence. This applies to ping
-			// messages as well. We do not write it after errors, otherwise our logs would get sent into the void.
-			await _console.WriteToStdoutAsync(_options.DaemonExecutionTerminationSequence).ConfigureAwait(false);
-			await _console.WriteToStderrAsync(_options.DaemonExecutionTerminationSequence).ConfigureAwait(false);
-
 			// If we should keep it alive (which is notably the default), do that.
-			if (_options.KeepAlive) continue;
+			if (_options.KeepAlive)
+			{
+				// After every *successful* execution, we need to write the execution sequence. This applies to ping
+				// messages as well. We do not write it after errors, otherwise our logs would get sent into the void.
+				await _console.WriteToStdoutAsync(_options.DaemonExecutionTerminationSequence).ConfigureAwait(false);
+				await _console.WriteToStderrAsync(_options.DaemonExecutionTerminationSequence).ConfigureAwait(false);
+				continue;
+			}
 
 			// Otherwise, we just stop the processing at this point.
 			break;


### PR DESCRIPTION
Closes SIANXSVC-1206

### To test it

1. Open the NativeAOT example (`cd examples/NativeAOT`)
1. Create a `payload.json` with the following contents:
	```json
	{"context":{"type":"integration-test","async":true,"date":"2024-01-01T00:00:00Z"},"event":{"type":"object","data":{"firstName":"Alexander","lastName":"Windbichler"}}}
	```
1. Execute the example with the following command:

	   dotnet run Hello ++ 0 ++ < payload.json

You should see both the logs and the output. In order to check that the redirection works as expected, redirect the stderr to `/dev/null`, like so:

	dotnet run Hello ++ 0 ++ < payload.json 2> /dev/null

The only result is the JSON, with a leading `++`. This matches the behaviour of *go-e5e*.