### PR TITLE
SIANXSVC-1186: Terminate application after writing metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,24 @@ await host.RunAsync();
 
 Further examples can be found in the [examples folder](./examples).
 
+### Note on startup initialization
+
+Due to the fact that the communication with e5e relies on the `IHost` to run, any initialization code should
+**not** be done before starting the host. It **must** be done after starting the host, for example by splitting
+up the `RunAsync` call like in the example below.
+
+```csharp
+using var host = /* ...omitted for brevity */
+
+// Don't do this or bad things are going to happen.
+await SomeExtremelyLongStartupTask();
+
+// Instead do this:
+await host.StartAsync();
+await SomeExtremelyLongStartupTask();
+await host.WaitForShutdownAsync();
+```
+
 # Supported versions
 
 |                        | Supported |

--- a/src/Anexia.E5E.Tests/Integration/StartupTests.cs
+++ b/src/Anexia.E5E.Tests/Integration/StartupTests.cs
@@ -2,9 +2,12 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Anexia.E5E.Abstractions.Termination;
 using Anexia.E5E.Runtime;
 using Anexia.E5E.Serialization;
 using Anexia.E5E.Tests.TestHelpers;
+
+using Microsoft.Extensions.DependencyInjection;
 
 using Xunit;
 using Xunit.Abstractions;
@@ -36,5 +39,7 @@ public class StartupTests : IntegrationTestBase
 		cts.Token.Register(() => Assert.Fail("Shutdown took longer than three seconds"), true);
 
 		await Host.WaitForShutdownAsync(cts.Token);
+		var terminator = Host.Inner.Services.GetRequiredService<ITerminator>() as TerminatorMock;
+		Assert.True(terminator?.Called);
 	}
 }

--- a/src/Anexia.E5E.Tests/TestHelpers/TerminatorMock.cs
+++ b/src/Anexia.E5E.Tests/TestHelpers/TerminatorMock.cs
@@ -1,0 +1,10 @@
+using Anexia.E5E.Abstractions.Termination;
+
+namespace Anexia.E5E.Tests.TestHelpers;
+
+public class TerminatorMock : ITerminator
+{
+	public void Exit() { Called = true; }
+
+	public bool Called { get; private set; }
+}

--- a/src/Anexia.E5E.Tests/TestHelpers/TestHostBuilder.cs
+++ b/src/Anexia.E5E.Tests/TestHelpers/TestHostBuilder.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Anexia.E5E.Abstractions;
+using Anexia.E5E.Abstractions.Termination;
 using Anexia.E5E.Extensions;
 using Anexia.E5E.Functions;
 using Anexia.E5E.Runtime;
@@ -53,7 +54,11 @@ public class TestHostBuilder
 	public Task StartAsync(int maximumLifetimeMs = 5000)
 	{
 		// In order to override the default implementation, we need to call this just before we build our host.
-		_hb.ConfigureServices(services => services.AddSingleton<IConsoleAbstraction, TestConsoleAbstraction>());
+		_hb.ConfigureServices(services =>
+		{
+			services.AddSingleton<IConsoleAbstraction, TestConsoleAbstraction>();
+			services.AddSingleton<ITerminator, TerminatorMock>();
+		});
 		_host = _hb.Build();
 
 		// Shutdown the host automatically after five seconds, there's no test that should run that long.

--- a/src/Anexia.E5E/Abstractions/Termination/EnvironmentTerminator.cs
+++ b/src/Anexia.E5E/Abstractions/Termination/EnvironmentTerminator.cs
@@ -1,0 +1,6 @@
+namespace Anexia.E5E.Abstractions.Termination;
+
+internal sealed class EnvironmentTerminator : ITerminator
+{
+	public void Exit() => Environment.Exit(0);
+}

--- a/src/Anexia.E5E/Abstractions/Termination/ITerminator.cs
+++ b/src/Anexia.E5E/Abstractions/Termination/ITerminator.cs
@@ -1,0 +1,10 @@
+namespace Anexia.E5E.Abstractions.Termination;
+
+/// <summary>
+/// Because the usage of <see cref="Environment.Exit"/> would also crash our test processes, it is abstracted.
+/// By default, the <see cref="EnvironmentTerminator"/> is used as implementation.
+/// </summary>
+internal interface ITerminator
+{
+	void Exit();
+}

--- a/src/Anexia.E5E/Anexia.E5E.csproj
+++ b/src/Anexia.E5E/Anexia.E5E.csproj
@@ -55,4 +55,9 @@
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0"/>
 		<PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="All"/>
 	</ItemGroup>
+
+	<ItemGroup>
+		<!-- Make the internal members visible to Anexia.E5E.Tests -->
+		<InternalsVisibleTo Include="$(AssemblyName).Tests"/>
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
Closes SIANXSVC-1186

## Proof of concept

In order to test that the changes work, the following code was used:

```csharp
using Anexia.E5E.Extensions;
using Anexia.E5E.Functions;

var host = Host.CreateDefaultBuilder(args)
	.UseAnexiaE5E(_ => {}) // ignore the setup this time
	.UseConsoleLifetime()
	.Build();

await host.StartAsync();

await Task.Delay(10000); // imitate a long startup task

await host.WaitForShutdownAsync();
```

If I run this code with `dotnet run metadata`, the application prints the metadata and terminates immediately.

## Caveats

Unfortunately, `Environment.Exit` would also end the test processes, therefore it had to be abstracted a bit.
