### PR TITLE
SIANXSVC-1214: Replace codecov with codeclimate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,19 @@ jobs:
     - run: dotnet restore
 
     - name: Run tests with coverage
-      run: dotnet test --no-restore --collect:"XPlat Code Coverage" /p:CoverletOutputFormat=opencover --logger trx --results-directory "test-results"
+      run: >
+        dotnet test
+        --no-restore
+        --collect:"XPlat Code Coverage"
+        /p:CoverletOutputFormat=cobertura
+        --logger trx
+        --results-directory "test-results"
+        --
+        DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.ExcludeByFile="**/*.g.cs"
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+    - name: Upload coverage to Codeclimate
+      uses: paambaati/codeclimate-action@v5
+      env:
+        CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+      with:
+        coverageLocations: "test-results/**/coverage.cobertura.xml:cobertura"

--- a/.gitignore
+++ b/.gitignore
@@ -120,5 +120,6 @@ fabric.properties
 # End of https://www.toptal.com/developers/gitignore/api/dotnetcore,visualstudiocode,intellij+all
 *.DotSettings.user
 TestResults/
+/test-results/
 *.nupkg
 *.snupkg

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ dotnet-e5e
 ==========
 [![](https://img.shields.io/nuget/v/Anexia.E5E "NuGet version badge")](https://www.nuget.org/packages/Anexia.E5E)
 [![](https://github.com/anexia/dotnet-e5e/actions/workflows/test.yml/badge.svg?branch=main "Test status")](https://github.com/anexia/dotnet-e5e/actions/workflows/test.yml)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/e632c5b96f75865745d9/test_coverage)](https://codeclimate.com/github/anexia/dotnet-e5e/test_coverage)
 
 `dotnet-e5e` is a client library for Anexia e5e - our *Functions as a Service* offering.
 With our client library, it's easy to build functions that can scale indefinitely!


### PR DESCRIPTION
This PR replaces the codecov GitHub Action with an upload to CodeClimate, which is in alignment with other teams.
This effectively supersedes #21.
