### PR TITLE
SIANXSVC-1214: Use lcov for CodeClimate reports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,7 @@ jobs:
       run: >
         dotnet test
         --no-restore
-        --collect:"XPlat Code Coverage"
-        /p:CoverletOutputFormat=cobertura
+        --collect:"XPlat Code Coverage;Format=lcov"
         --logger trx
         --results-directory "test-results"
         --
@@ -39,4 +38,4 @@ jobs:
       env:
         CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
       with:
-        coverageLocations: "test-results/**/coverage.cobertura.xml:cobertura"
+        coverageLocations: "test-results/**/coverage.info:lcov"


### PR DESCRIPTION
Even though the Code Coverage report is correct and other platforms like GitLab do not have a problem understanding it, the CodeClimate reporter struggles with double slashes that seem to be introduced by itself.
This is also tracked in an issue, which is open since three years with no intent of fixing it. Therefore, I assume this is not going to be closed soon.

https://github.com/codeclimate/test-reporter/issues/458

As a workaround, we're now using the lcov format.
