### PR TITLE
Remove myself from dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    assignees: [nachtjasmin, beachmachine]
+    assignees: [beachmachine]
 
   - package-ecosystem: "nuget"
     directory: "/src"
     schedule:
       interval: "weekly"
-    assignees: [nachtjasmin, beachmachine]
+    assignees: [beachmachine]


### PR DESCRIPTION
That's probably even just a workaround, in the best case, we should create a group like "anexia/dotnet-developers" or sth similiar. But that's up to you and the management.